### PR TITLE
Release/1.0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: print
 
 PDK=ihp-sg13g2
 SHARED_DIR=$(abspath ./shared_xserver)
-DOCKER_IMAGE_TAG=isaiassh/unic-cass-tools:1.0.4
+DOCKER_IMAGE_TAG=isaiassh/unic-cass-tools:1.0.5
 
 ifneq (,$(ROOT))
 _DOCKER_ROOT_USER=--user root

--- a/images/final_structure/configure/.bashrc
+++ b/images/final_structure/configure/.bashrc
@@ -61,7 +61,7 @@ _path_add_tool_bin      "magic"
 _path_add_tool_bin      "netgen"
 _path_add_tool_bin      "ngspice"
 # _path_add_tool_bin      "nvc"
-# _path_add_tool_bin      "openroad"  # Use OpenROAD from Nix instead to avoid ODR violations
+# _path_add_tool_bin      "openroad"  # Added conditionally above to avoid ODR violation with LibreLane's OpenROAD from Nix
 # _path_add_tool_bin      "opensta"
 _path_add_tool_bin	    "openvaf"
 # _path_add_tool_custom   "osic-multitool"
@@ -161,8 +161,11 @@ alias grep="grep --color=auto"
 export USER=designer
 
 export CMAKE_PACKAGE_ROOT_ARGS="$CMAKE_PACKAGE_ROOT_ARGS -D SWIG_ROOT=$TOOLS/common -D Eigen3_ROOT=$TOOLS/common -D GTest_ROOT=$TOOLS/common -D LEMON_ROOT=$TOOLS/common -D spdlog_ROOT=$TOOLS/common -D ortools_ROOT=$TOOLS/common"
-# export PATH="$TOOLS/common/bin:$PATH"  # Commented: or-tools conflicts with Nix
-# export LD_LIBRARY_PATH="$TOOLS/common/lib64:$TOOLS/common/lib:$LD_LIBRARY_PATH"  # Commented: conflicts with Nix
+
+# OpenROAD configuration: Add to PATH but disable LD_LIBRARY_PATH to prevent ODR violation
+export PATH="$TOOLS/openroad/bin:$TOOLS/common/bin:$PATH"
+# LD_LIBRARY_PATH disabled to prevent ODR violation between /opt/common libraries and LibreLane's internal OpenROAD
+# export LD_LIBRARY_PATH="$TOOLS/common/lib64:$TOOLS/common/lib:$LD_LIBRARY_PATH"
 
 # ORFS Makefile overwrited variables
 export ORFS_DIR=$TOOLS/OpenROAD-flow-scripts

--- a/images/orfs/install.sh
+++ b/images/orfs/install.sh
@@ -3,18 +3,135 @@
 set -ex
 cd /tmp
 
-# This project is going to have the entire git history so each designer can
-# Use different commits
-
-ORFS_REPO_URL=https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
-ORFS_NAME=OpenROAD-flow-scripts
-ORFS_DIR=$TOOLS/$ORFS_NAME
-
+# Clone the OpenROAD repository
 git clone $ORFS_REPO_URL $ORFS_NAME || true
 cd $ORFS_NAME
 git checkout $ORFS_REPO_COMMIT
 
-# Avoid klayout incompatibility with klive and -zz
-sed -i "s/ -zz / -b /g" flow/Makefile
+# Initialize and update git submodules
+git submodule update --init --recursive
 
-mv /tmp/$ORFS_NAME $ORFS_DIR
+# Install dependencies using OpenROAD's dependency installer
+./etc/DependencyInstaller.sh -base
+
+# STRATEGIC APPROACH: Apply fix for fmt v7 compatibility
+# The code in dbBlock.cpp uses old fmt API that's incompatible with fmt v7
+# We need to fix this before compilation
+echo "Applying fmt v7 compatibility fix..."
+
+# Fix the dbBlock.cpp compatibility issue
+cat > /tmp/dbBlock_fix.patch << 'EOF'
+--- a/src/odb/src/db/dbBlock.cpp
++++ b/src/odb/src/db/dbBlock.cpp
+@@ -3782,7 +3782,7 @@ std::string _dbBlock::makeNewName(dbModInst* inst, const char* base_name, const
+       {  // Use fmt if available
+         fmt::basic_memory_buffer<char> buf;
+         buf.reserve(est_size);
+-        buf.append(fmt::string_view(base_name));
++        buf.append(base_name, base_name + strlen(base_name));
+         fmt::format_to(std::back_inserter(buf), "{}_{}", index, suffix);
+         *counter = index++;
+         return std::string(buf.data(), buf.size());
+EOF
+
+# Apply the fix to dbBlock.cpp
+cd src/odb/src/db
+if grep -q "buf.append(fmt::string_view(base_name))" dbBlock.cpp; then
+    sed -i 's/buf.append(fmt::string_view(base_name));/buf.append(base_name, base_name + strlen(base_name));/' dbBlock.cpp
+    echo "Applied fmt v7 compatibility fix to dbBlock.cpp"
+fi
+cd /tmp/openroad
+
+# Apply the fix to dbSdcNetwork.cc
+cd src/dbSta/src
+# Fix the dbSdcNetwork.cc compatibility issue - name() returns const char*
+python3 << 'EOF'
+import re
+
+with open('dbSdcNetwork.cc', 'r') as f:
+    content = f.read()
+
+# Replace std::string_view(name(child)) with pointer arithmetic
+content = re.sub(
+    r'(\s+)path_buffer\.append\(std::string_view\(name\(child\)\)\);',
+    r'\1const char* child_nm = name(child);\n\1path_buffer.append(child_nm, child_nm + strlen(child_nm));',
+    content
+)
+
+with open('dbSdcNetwork.cc', 'w') as f:
+    f.write(content)
+    
+print("Applied fmt v7 compatibility fix to dbSdcNetwork.cc")
+EOF
+cd /tmp/openroad
+
+# Apply the fix to dbNetwork.cc  
+cd src/dbSta/src
+python3 << 'EOF'
+import re
+
+with open('dbNetwork.cc', 'r') as f:
+    content = f.read()
+
+# Try to fix std::string_view(modnet_name) - modnet_name is likely a string
+if 'std::string_view(modnet_name)' in content:
+    content = re.sub(
+        r'full_path_buf\.append\(std::string_view\(modnet_name\)\)',
+        r'full_path_buf.append(modnet_name.data(), modnet_name.data() + modnet_name.size())',
+        content
+    )
+    print("Applied fmt v7 compatibility fix to dbNetwork.cc (with data/size)")
+else:
+    # It might just be full_path_buf.append(modnet_name)
+    content = re.sub(
+        r'full_path_buf\.append\(modnet_name\)',
+        r'full_path_buf.append(modnet_name.data(), modnet_name.data() + modnet_name.size())',
+        content
+    )
+    print("Applied fmt v7 compatibility fix to dbNetwork.cc (direct)")
+    
+with open('dbNetwork.cc', 'w') as f:
+    f.write(content)
+EOF
+cd /tmp/openroad
+
+# Patch: Install spdlog development package to provide spdlog::spdlog target
+apt-get update && apt-get install -y libspdlog-dev 2>/dev/null || echo "spdlog-dev not available, will build from source"
+
+# Create build directory
+mkdir -p build
+cd build
+
+# Configure with CMake - use system libraries for essential ones, build problematic ones from source
+# This allows essential libraries to be found while avoiding conflicts with problematic libraries
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$TOOLS/$ORFS_NAME \
+    -DCMAKE_PREFIX_PATH="/opt/common" \
+    -DUSE_SYSTEM_BOOST=OFF \
+    -DUSE_SYSTEM_EIGEN3=OFF \
+    -DUSE_SYSTEM_LEMON=OFF \
+    -DUSE_SYSTEM_GTEST=ON \
+    -DUSE_SYSTEM_ORTOOLS=OFF \
+    -DUSE_SYSTEM_SWIG=ON \
+    -DUSE_SYSTEM_SPDLOG=OFF \
+    -DUSE_SYSTEM_CUDD=OFF \
+    -DUSE_SYSTEM_FMT=OFF \
+    -DSPDLOG_BUILD_EXAMPLE=OFF \
+    -DSPDLOG_BUILD_TESTS=OFF \
+    -DSPDLOG_BUILD_SHARED=OFF \
+    -DFMT_DOC=OFF \
+    -DFMT_TEST=OFF \
+    -DFORCE_SPDLOG_BUILD=ON
+
+# Build OpenROAD with more parallelism for faster compilation
+# Use available CPU cores for faster build
+make -j$(nproc)
+
+# Install OpenROAD
+make install
+
+# No libraries to restore since we didn't hide anything
+
+# Create symlinks for easy access
+ln -sf $TOOLS/$ORFS_NAME/bin/openroad $TOOLS/$ORFS_NAME/bin/or


### PR DESCRIPTION
# Pull Request

## Description
This commit migrates from [OpenROAD-flow-scripts](github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) to the core [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD) repository. It addresses compatibility across versions of OpenROAD and resolves library conflicts between a standalone install and LibreLane’s Nix-managed version.

Fixes #6 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Additional notes
- Apply fmt v7 compatibility patches to dbBlock.cpp, dbSdcNetwork.cc, and dbNetwork.cc
- Correct append calls for fmt v7 (pointer arithmetic vs. string_view)
- LibreLane linked its Nix-provided OpenROAD, which conflicted with a /opt/openroad installation. Fix: Disabled LD_LIBRARY_PATH pointing to /opt/common/lib* to prevent mixing libraries.